### PR TITLE
Updated Fipsum extension so hidden elements are ignored

### DIFF
--- a/fipsum.js
+++ b/fipsum.js
@@ -1,101 +1,111 @@
 function fipsum() {
 
-	var els 			= document.querySelectorAll('input');
-	var textareas = document.querySelectorAll('textarea');
-	var length 		= els.length
-		, ta_length = textareas.length
-		, i 				= 0;
+	var els,textarea,length,ta_length,i;
+
+	els 		= document.querySelectorAll('input');
+	textareas   = document.querySelectorAll('textarea');
+	length 		= els.length;
+	ta_length 	= textareas.length;
+	i 			= 0;
 
 	for ( i; i < length; i ++ ) {
-		switch ( els[i].type ) {
-			case 'submit' :
-				break;
 
-			case 'text' :
-				els[i].value = getRandomStringWithSpaces(1, 4);
-				break;
+		if (els[i].isVisible(els[i])) {
+			switch ( els[i].type ) {
+				case 'submit' :
+				case 'hidden' :
+					break;
 
-			case 'url' :
-				els[i].value = ('http://' + getRandomStringWithNoSpaces(1, 4) + '.com');
-				break;
+				case 'text' :
+					els[i].value = getRandomStringWithSpaces(1, 4);
+					break;
 
-			case 'email' :
-				els[i].value = (getRandomStringWithNoSpaces(1, 2) + '@' + getRandomStringWithNoSpaces(1, 4) + '.com');
-				break;
+				case 'url' :
+					els[i].value = ('http://' + getRandomStringWithNoSpaces(1, 4) + '.com');
+					break;
 
-			case 'date' :
-				els[i].value = getRandomDate();
-				break;
+				case 'email' :
+					els[i].value = (getRandomStringWithNoSpaces(1, 2) + '@' + getRandomStringWithNoSpaces(1, 4) + '.com');
+					break;
 
-			case 'time' :
-				els[i].value = getRandomTime();
-				break;
+				case 'date' :
+					els[i].value = getRandomDate();
+					break;
 
-			case 'datetime' :
-				els[i].value = getRandomDate() + ' ' + getRandomTime();
-				break;
+				case 'time' :
+					els[i].value = getRandomTime();
+					break;
 
-			case 'month' :
-				els[i].value = getRandomMonthYear();
-				break;
+				case 'datetime' :
+				case 'datetime-local' :
+					els[i].value = getRandomDate() + 'T' + getRandomTime();
+					break;
 
-			case 'week' :
-				els[i].value = getRandomWeek();
-				break;
+				case 'month' :
+					els[i].value = getRandomMonthYear();
+					break;
 
-			case 'number' :
-			case 'range' :
+				case 'week' :
+					els[i].value = getRandomWeek();
+					break;
 
-				if (els[i].max) {
-					var max = els[i].max;
-				}
-				else {
-					var max = randomFromTo(0, 1000);
-				}
+				case 'number' :
+				case 'range' :
 
-				if (els[i].min) {
-					var min = els[i].min;
-				}
-				else {
-					var min = randomFromTo(0, 1000);
-				}
+					var max,min,value;
+					if (els[i].max) {
+						max = els[i].max;
+					}
+					else {
+						max = randomFromTo(0, 1000);
+					}
 
-				var value = randomFromTo(min, max);
+					if (els[i].min) {
+						min = els[i].min;
+					}
+					else {
+						min = randomFromTo(0, 1000);
+					}
 
-				if (els[i].step) {
-					value -= (value % els[i].step);
-				}
+					value = randomFromTo(min, max);
 
-				els[i].value = value;
-				break;
+					if (els[i].step) {
+						value -= (value % els[i].step);
+					}
 
-			case 'tel' :
-				els[i].value = getRandomTel();
-				break;
+					els[i].value = value;
+					break;
 
-			case 'color' :
-				els[i].value = getRandomColor();
-				break;
+				case 'tel' :
+					els[i].value = getRandomTel();
+					break;
 
-			case 'checkbox' :
+				case 'color' :
+					els[i].value = getRandomColor();
+					break;
+
+				case 'checkbox' :
 				case 'radio' :
-					if (Math.random() < .5) {
+					if (Math.random() < 0.5) {
 						els[i].checked = true;
 					}
 					break;
 
-			case 'textarea' :
-				els[i].value = getRandomParagraphWithSpaces(1, 4);
-				break;
+				case 'textarea' :
+					els[i].value = getRandomParagraphWithSpaces(1, 4);
+					break;
 
-			default :
-				els[i].value = getRandomStringWithSpaces(1, 4);
-				break;
+				default :
+					els[i].value = getRandomStringWithSpaces(1, 4);
+					break;
+			}
 		}
-	};
+	}
 
 	for ( var t = 0; t < ta_length; t++ ) {
-		textareas[t].value = getRandomParagraphWithSpaces(10, 20)
+		if (textareas[t].isVisible(textareas[t])) {
+			textareas[t].value = getRandomParagraphWithSpaces(10, 20);
+		}
 	}
 
 }
@@ -147,7 +157,7 @@ function getRandomDate() {
 }
 
 function getRandomTime() {
-	return randomFromTo(1, 12) + ':' + zeroPad(randomFromTo(1, 59), 2) + ':' + zeroPad(randomFromTo(1, 59), 2);
+	return zeroPad(randomFromTo(0, 23), 2) + ':' + zeroPad(randomFromTo(1, 59), 2) + ':' + zeroPad(randomFromTo(1, 59), 2);
 }
 
 function getRandomMonthYear() {
@@ -180,7 +190,6 @@ var pseudoSentences = Array('Morbi leo risus, porta ac consectetur ac, vestibulu
 function randomFromTo(from, to) {
 	return Math.floor( Math.random() * (to - from + 1) + from );
 }
-
 
 // initialize the context menu
 chrome.contextMenus.create({

--- a/global.html
+++ b/global.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
 <html>
   <head>
-	  <meta charset="utf-8">
-  	<script src="fipsum.js"></script>
+      <meta charset="utf-8">
+      <script src="visibility.js"></script>
+      <script src="fipsum.js"></script>
   </head>
-  
+
   <body>
   </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,9 @@
 {
-   "background_page": "global.html",
+   "background": {
+      "page": "global.html"
+   },
    "content_scripts": [ {
-      "js": [ "fipsum.js" ],
+      "js": [ "visibility.js", "fipsum.js" ],
       "matches": [ "\u003Call_urls\u003E" ]
    } ],
    "content_security_policy": "default-src * 'unsafe-inline'",
@@ -15,5 +17,6 @@
    "name": "Fipsum",
    "permissions": [ "contextMenus", "\u003Call_urls\u003E", "tabs" ],
    "update_url": "http://clients2.google.com/service/update2/crx",
-   "version": "0.1"
+   "version": "0.2",
+   "manifest_version": 2
 }

--- a/test.html
+++ b/test.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Fipsum Test</title>
+        <style type="text/css">
+            html,
+            body {
+                font-size: 16px;
+                font-family: sans-serif;
+            }
+            table {
+                border: 1px solid #CCC;
+                min-width: 750px;
+            }
+            table th {
+                text-align: left;
+                padding: 0.5em;
+            }
+            table td.type {
+                background: #EFEFEF;
+                padding: 0.5em;
+                width: 260px;
+                text-align: right;
+            }
+            table input {
+                width: 100%;
+                padding: 0.25em;
+                box-sizing: border-box;
+            }
+        </style>
+    </head>
+    <body>
+        <table>
+            <thead>
+                <tr>
+                    <th class="type">Type</th>
+                    <th class="input">Input</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="type">
+                        Text
+                    </td>
+                    <td class="input">
+                        <input type="text" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        URL
+                    </td>
+                    <td class="input">
+                        <input type="url" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Email
+                    </td>
+                    <td class="input">
+                        <input type="email" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Date
+                    </td>
+                    <td class="input">
+                        <input type="date" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Time
+                    </td>
+                    <td class="input">
+                        <input type="time" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Datetime
+                    </td>
+                    <td class="input">
+                        <input type="datetime-local" id="datetime-local " />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Month
+                    </td>
+                    <td class="input">
+                        <input type="month" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Week
+                    </td>
+                    <td class="input">
+                        <input type="week" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Number
+                    </td>
+                    <td class="input">
+                        <input type="number" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Range
+                    </td>
+                    <td class="input">
+                        <input type="range" min="0" max="100" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Tel
+                    </td>
+                    <td class="input">
+                        <input type="tel" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Color
+                    </td>
+                    <td class="input">
+                        <input type="color" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Checkbox
+                    </td>
+                    <td class="input">
+                        <input type="checkbox" name="checkbox1" value="1" />
+                        <input type="checkbox" name="checkbox2" value="2" />
+                        <input type="checkbox" name="checkbox3" value="3" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Radio
+                    </td>
+                    <td class="input">
+                        <input type="radio" name="radio" value="1" />
+                        <input type="radio" name="radio" value="2" />
+                        <input type="radio" name="radio" value="3" />
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Textarea
+                    </td>
+                    <td class="input">
+                        <textarea></textarea>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Hidden
+                    </td>
+                    <td class="input">
+                        <input type="hidden" id="hidden-input" value="This is a hidden element and should remain unaffected" />
+                        Value: <span id="hidden-val"></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Text (parent hidden with CSS)
+                    </td>
+                    <td class="input">
+                        <div style="display:none">
+                            <input type="text" id="parent-hidden-css-input" value="This is a hidden element and should remain unaffected" />
+                        </div>
+                        Value: <span id="parent-hidden-css-val"></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Textarea (parent hidden with CSS)
+                    </td>
+                    <td class="input">
+                        <div style="display:none">
+                            <textarea id="parent-hidden-textarea-input">This is a hidden element and should remain unaffected</textarea>
+                        </div>
+                        Value: <span id="parent-hidden-textarea-val"></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Text (hidden with CSS)
+                    </td>
+                    <td class="input">
+                        <input style="display:none" type="text" id="hidden-css-input" value="This is a hidden element and should remain unaffected" />
+                        Value: <span id="hidden-css-val"></span>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="type">
+                        Textarea (hidden with CSS)
+                    </td>
+                    <td class="input">
+                        <textarea style="display:none" id="hidden-textarea-input">This is a hidden element and should remain unaffected</textarea>
+                        Value: <span id="hidden-textarea-val"></span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <script type="text/javascript">
+
+            setInterval(function() {
+
+                var input, target;
+
+                input = document.getElementById('hidden-input');
+                target = document.getElementById('hidden-val');
+                target.innerHTML = input.value;
+
+                input = document.getElementById('parent-hidden-css-input');
+                target = document.getElementById('parent-hidden-css-val');
+                target.innerHTML = input.value;
+
+                input = document.getElementById('hidden-css-input');
+                target = document.getElementById('hidden-css-val');
+                target.innerHTML = input.value;
+
+                input = document.getElementById('parent-hidden-textarea-input');
+                target = document.getElementById('parent-hidden-textarea-val');
+                target.innerHTML = input.value;
+
+                input = document.getElementById('hidden-textarea-input');
+                target = document.getElementById('hidden-textarea-val');
+                target.innerHTML = input.value;
+
+            }, 100);
+
+        </script>
+    </body>
+</html>

--- a/visibility.js
+++ b/visibility.js
@@ -1,0 +1,116 @@
+/**
+ * Author: Jason Farrell
+ * Author URI: http://useallfive.com/
+ *
+ * Description: Checks if a DOM element is truly visible.
+ * Package URL: https://github.com/UseAllFive/true-visibility
+ */
+Element.prototype.isVisible = function() {
+
+    'use strict';
+
+    /**
+     * Checks if a DOM element is visible. Takes into
+     * consideration its parents and overflow.
+     *
+     * @param (el)      the DOM element to check if is visible
+     *
+     * These params are optional that are sent in recursively,
+     * you typically won't use these:
+     *
+     * @param (t)       Top corner position number
+     * @param (r)       Right corner position number
+     * @param (b)       Bottom corner position number
+     * @param (l)       Left corner position number
+     * @param (w)       Element width number
+     * @param (h)       Element height number
+     */
+    function _isVisible(el, t, r, b, l, w, h) {
+        var p = el.parentNode,
+                VISIBLE_PADDING = 2;
+
+        if ( !_elementInDocument(el) ) {
+            return false;
+        }
+
+        //-- Return true for document node
+        if ( 9 === p.nodeType ) {
+            return true;
+        }
+
+        //-- Return false if our element is invisible
+        if (
+             '0' === _getStyle(el, 'opacity') ||
+             'none' === _getStyle(el, 'display') ||
+             'hidden' === _getStyle(el, 'visibility')
+        ) {
+            return false;
+        }
+
+        if (
+            'undefined' === typeof(t) ||
+            'undefined' === typeof(r) ||
+            'undefined' === typeof(b) ||
+            'undefined' === typeof(l) ||
+            'undefined' === typeof(w) ||
+            'undefined' === typeof(h)
+        ) {
+            t = el.offsetTop;
+            l = el.offsetLeft;
+            b = t + el.offsetHeight;
+            r = l + el.offsetWidth;
+            w = el.offsetWidth;
+            h = el.offsetHeight;
+        }
+        //-- If we have a parent, let's continue:
+        if ( p ) {
+            //-- Check if the parent can hide its children.
+            if ( ('hidden' === _getStyle(p, 'overflow') || 'scroll' === _getStyle(p, 'overflow')) ) {
+                //-- Only check if the offset is different for the parent
+                if (
+                    //-- If the target element is to the right of the parent elm
+                    l + VISIBLE_PADDING > p.offsetWidth + p.scrollLeft ||
+                    //-- If the target element is to the left of the parent elm
+                    l + w - VISIBLE_PADDING < p.scrollLeft ||
+                    //-- If the target element is under the parent elm
+                    t + VISIBLE_PADDING > p.offsetHeight + p.scrollTop ||
+                    //-- If the target element is above the parent elm
+                    t + h - VISIBLE_PADDING < p.scrollTop
+                ) {
+                    //-- Our target element is out of bounds:
+                    return false;
+                }
+            }
+            //-- Add the offset parent's left/top coords to our element's offset:
+            if ( el.offsetParent === p ) {
+                l += p.offsetLeft;
+                t += p.offsetTop;
+            }
+            //-- Let's recursively check upwards:
+            return _isVisible(p, t, r, b, l, w, h);
+        }
+        return true;
+    }
+
+    //-- Cross browser method to get style properties:
+    function _getStyle(el, property) {
+        if ( window.getComputedStyle ) {
+            return document.defaultView.getComputedStyle(el,null)[property];
+        }
+        if ( el.currentStyle ) {
+            return el.currentStyle[property];
+        }
+    }
+
+    function _elementInDocument(element) {
+        while (element = element.parentNode) {
+            if (element == document) {
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    return _isVisible(this);
+
+};


### PR DESCRIPTION
Updated Fipsum extension so that hidden elements (either by CSS or as the `type` attribute) don't get filled.

In addition:
- Tidied up some markup layout/keeping JSHint happy
- Using handy lib by Jason Farrell to detect if element is hidden by parent stylings
- Added a "test" page to quickly test elements
- `datetime` is deprecated, so using `datetime-local`
- Changed format of getRandomTime() to be 24 hour / zeropadded hours
- Format for `datetime-local` is YYYY-MM-DDTHH:MM:SS, updated to suit
